### PR TITLE
Remove the old instructions about adding ST's html context

### DIFF
--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -56,18 +56,6 @@ You'll need the [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter) 
 
 Unless you're using `.html` for your Svelte components, you'll need to configure Sublime to associate the appropriate file extension with the `text.html` syntax. Open any Svelte component, and go to **View > Syntax > Open all with current extension as... > HTML**.
 
-Then, you'll need to tell SublimeLinter-eslint to lint entire files with the `text.html` syntax, and not just the contents of their `<script>` tags (which is the default). In your SublimeLinter configuration, you'll need to add `text.html` to `linters`.`eslint`.`selector`. If you're starting with the default values, this would mean:
-
-```json
-{
-  "linters": {
-    "eslint": {
-      "selector": "source.js - meta.attribute-with-value, text.html"
-    }
-  }
-}
-```
-
 Reload Sublime and give it a go!
 
 # Vim


### PR DESCRIPTION
As of SublimeLinter-eslint 2.4.0, the plugin automatically looks for the text.html context if you're using this plugin https://github.com/SublimeLinter/SublimeLinter-eslint/pull/287/files#diff-6c1f4f1574c85da37dc4dd59341c9a39R31

I haven't tested this at all in my browser yet, I just read the source code change and read the related issue in the SublimeLinter-eslint.