### PR TITLE
Drop Node 8 support. Add Node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [8, 10, 12]
+        node-version: [10, 12, 14]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - run: git config --global core.autocrlf false


### PR DESCRIPTION
Node 8 is no longer supported and the newest versions of `eslint`, `rollup-plugin-svelte`, `rollup`, `webpack`, and `sapper` have all dropped support for Node 8