### PR TITLE
update expected messages in tests

### DIFF
--- a/test/samples/block-filenames/expected.json
+++ b/test/samples/block-filenames/expected.json
@@ -2,11 +2,11 @@
 	{
 		"ruleId": "curly",
 		"line": 2,
-		"column": 2
+		"column": 12
 	},
 	{
 		"ruleId": "curly",
 		"line": 7,
-		"column": 2
+		"column": 11
 	}
 ]

--- a/test/samples/typescript-block-filenames/expected.json
+++ b/test/samples/typescript-block-filenames/expected.json
@@ -2,11 +2,11 @@
 	{
 		"ruleId": "curly",
 		"line": 2,
-		"column": 2
+		"column": 12
 	},
 	{
 		"ruleId": "curly",
 		"line": 7,
-		"column": 2
+		"column": 11
 	}
 ]

--- a/test/samples/typescript-lazy/expected.json
+++ b/test/samples/typescript-lazy/expected.json
@@ -158,14 +158,6 @@
 		"endColumn": 18
 	},
 	{
-		"ruleId": "module-script-reactive-declaration",
-		"severity": 1,
-		"line": 19,
-		"column": 10,
-		"endLine": 19,
-		"endColumn": 11
-	},
-	{
 		"ruleId": "missing-declaration",
 		"severity": 1,
 		"line": 23,

--- a/test/samples/typescript-peer-dependency/expected.json
+++ b/test/samples/typescript-peer-dependency/expected.json
@@ -158,14 +158,6 @@
 		"endColumn": 18
 	},
 	{
-		"ruleId": "module-script-reactive-declaration",
-		"severity": 1,
-		"line": 19,
-		"column": 10,
-		"endLine": 19,
-		"endColumn": 11
-	},
-	{
 		"ruleId": "missing-declaration",
 		"severity": 1,
 		"line": 23,

--- a/test/samples/typescript/expected.json
+++ b/test/samples/typescript/expected.json
@@ -158,14 +158,6 @@
 		"endColumn": 18
 	},
 	{
-		"ruleId": "module-script-reactive-declaration",
-		"severity": 1,
-		"line": 19,
-		"column": 10,
-		"endLine": 19,
-		"endColumn": 11
-	},
-	{
 		"ruleId": "missing-declaration",
 		"severity": 1,
 		"line": 23,


### PR DESCRIPTION
This is an alternative to and closes #125. As I mentioned on that PR, I'd prefer to update the tests rather than add a lockfile.

I want to continue to test against the latest versions of Svelte and ESLint. If we add a lockfile, the green tests would give us a false sense of security - and if we worked to keep it updated, that would time-consuming, hard to remember, and result in Git noise.

We can think about how to make these tests more robust in the future, but for now, I think this change makes sense.