### PR TITLE
Improve default setting for svelte3/ignore-styles

### DIFF
--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -22,11 +22,14 @@ const find_contextual_names = (compiler, node) => {
 		}
 	}
 };
+// ignore_styles when a `lang=` or `type=` attribute is present on the <style> tag
+const ignoreStylesFallback = ({ type, lang }) => !!type || !!lang;
 
 // extract scripts to lint from component definition
 export const preprocess = text => {
 	const compiler = processor_options.custom_compiler || default_compiler || (default_compiler = require('svelte/compiler'));
-	if (processor_options.ignore_styles) {
+	const ignore_styles = typeof processor_options.ignore_styles !== 'undefined' ? processor_options.ignore_styles : ignoreStylesFallback;
+	if (ignore_styles) {
 		// wipe the appropriate <style> tags in the file
 		text = text.replace(/<style(\s[^]*?)?>[^]*?<\/style>/gi, (match, attributes = '') => {
 			const attrs = {};
@@ -38,7 +41,7 @@ export const preprocess = text => {
 					attrs[attr.slice(0, p)] = '\'"'.includes(attr[p + 1]) ? attr.slice(p + 2, -1) : attr.slice(p + 1);
 				}
 			});
-			return processor_options.ignore_styles(attrs) ? match.replace(/\S/g, ' ') : match;
+			return ignore_styles(attrs) ? match.replace(/\S/g, ' ') : match;
 		});
 	}
 

--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -28,7 +28,7 @@ const ignoreStylesFallback = ({ type, lang }) => !!type || !!lang;
 // extract scripts to lint from component definition
 export const preprocess = text => {
 	const compiler = processor_options.custom_compiler || default_compiler || (default_compiler = require('svelte/compiler'));
-	const ignore_styles = typeof processor_options.ignore_styles !== 'undefined' ? processor_options.ignore_styles : ignoreStylesFallback;
+	const ignore_styles = processor_options.ignore_styles ? processor_options.ignore_styles : ignoreStylesFallback;
 	if (ignore_styles) {
 		// wipe the appropriate <style> tags in the file
 		text = text.replace(/<style(\s[^]*?)?>[^]*?<\/style>/gi, (match, attributes = '') => {


### PR DESCRIPTION
> svelte3/ignore-styles
>
> If you're using some sort of preprocessor on the component styles, then it's likely that when this plugin calls the Svelte compiler on your component, it will throw an exception.

This PR changes the default in this plugin to:
```js
  "svelte3/ignore-styles": ({ lang, type }) => !!lang || !!type,
```
_(a.k.a. Ignore styles when a `lang=` or `type=` attribute is present on the <style> tag)_

This would result is in less configuration when adding this plugin to a svelte project that uses a css preprocessor.

