### PR TITLE
feat: Upgraded unittests to ESLint 8.x

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -2,23 +2,27 @@
 
 process.chdir(__dirname);
 
-const { CLIEngine } = require('eslint');
+const { ESLint } = require('eslint');
 const assert = require('assert');
 const fs = require('fs');
 
-const cli = new CLIEngine({ reportUnusedDisableDirectives: true });
+const cli = new ESLint({ reportUnusedDisableDirectives: "error" });
 
-for (const name of fs.readdirSync('samples')) {
-	if (name[0] !== '.') {
-		console.log(name);
-		if (process.platform === 'win32' && !fs.existsSync(`samples/${name}/preserve_line_endings`)) {
-			fs.writeFileSync(`samples/${name}/Input.svelte`, fs.readFileSync(`samples/${name}/Input.svelte`).toString().replace(/\r/g, ''));
+async function run() {
+	for (const name of fs.readdirSync('samples')) {
+		if (name[0] !== '.') {
+			console.log(name);
+			if (process.platform === 'win32' && !fs.existsSync(`samples/${name}/preserve_line_endings`)) {
+				fs.writeFileSync(`samples/${name}/Input.svelte`, fs.readFileSync(`samples/${name}/Input.svelte`).toString().replace(/\r/g, ''));
+			}
+			const actual_messages = (await cli.lintFiles([`samples/${name}/Input.svelte`]))[0].messages
+			fs.writeFileSync(`samples/${name}/actual.json`, JSON.stringify(actual_messages, null, '\t'));
+			const expected_messages = JSON.parse(fs.readFileSync(`samples/${name}/expected.json`).toString());
+			assert.equal(actual_messages.length, expected_messages.length);
+			assert.deepStrictEqual(actual_messages, actual_messages.map((message, i) => ({ ...message, ...expected_messages[i] })));
+			console.log('passed!\n');
 		}
-		const actual_messages = cli.executeOnFiles([`samples/${name}/Input.svelte`]).results[0].messages;
-		fs.writeFileSync(`samples/${name}/actual.json`, JSON.stringify(actual_messages, null, '\t'));
-		const expected_messages = JSON.parse(fs.readFileSync(`samples/${name}/expected.json`).toString());
-		assert.equal(actual_messages.length, expected_messages.length);
-		assert.deepStrictEqual(actual_messages, actual_messages.map((message, i) => ({ ...message, ...expected_messages[i] })));
-		console.log('passed!\n');
 	}
 }
+
+run()


### PR DESCRIPTION
CLIEngine is removed in ESLint 8 
https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0

I've updated the tests and wrapped it in a async function (`lintFiles` is asynchronous)

Another fix to running the tests would be to modify the package.json:
change `"eslint": ">=6.0.0",` into `"eslint": ">=6.0.0 <8",`
(aka limit the eslint version to 7.x)