### PR TITLE
Use TS 4.5 `preserveValueImports` if it's available

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"@rollup/plugin-node-resolve": "^11.2.0",
 		"@typescript-eslint/eslint-plugin": "^5.8.1",
 		"@typescript-eslint/parser": "^5.8.1",
-		"eslint": ">=8.0.0",
+		"eslint": ">=7.0.0 < 8",
 		"rollup": "^2",
 		"sourcemap-codec": "1.4.8",
 		"svelte": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
 	},
 	"devDependencies": {
 		"@rollup/plugin-node-resolve": "^11.2.0",
-		"@typescript-eslint/eslint-plugin": "^4.14.2",
-		"@typescript-eslint/parser": "^4.14.2",
+		"@typescript-eslint/eslint-plugin": "^5.8.1",
+		"@typescript-eslint/parser": "^5.8.1",
 		"eslint": ">=6.0.0",
 		"rollup": "^2",
 		"sourcemap-codec": "1.4.8",
 		"svelte": "^3.2.0",
-		"typescript": "^4.0.0"
+		"typescript": "^4.5.4"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"@rollup/plugin-node-resolve": "^11.2.0",
 		"@typescript-eslint/eslint-plugin": "^5.8.1",
 		"@typescript-eslint/parser": "^5.8.1",
-		"eslint": ">=6.0.0",
+		"eslint": ">=8.0.0",
 		"rollup": "^2",
 		"sourcemap-codec": "1.4.8",
 		"svelte": "^3.2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -4,12 +4,12 @@ process.chdir(__dirname);
 
 const { ESLint } = require('eslint');
 const assert = require('assert');
-const fs = require('fs/promises');
+const fs = require('fs');
 
 const linter = new ESLint({ reportUnusedDisableDirectives: "error" });
 
 async function run() {
-	const tests = (await fs.readdir('samples')).filter(name => name[0] !== '.');
+	const tests = fs.readdirSync('samples').filter(name => name[0] !== '.');
 
 	for (const name of tests) {
 		console.log(name);
@@ -19,17 +19,17 @@ async function run() {
 		const path_expected = `samples/${name}/expected.json`;
 		const path_actual = `samples/${name}/actual.json`;
 
-		if (process.platform === 'win32' && !(await exists(path_ple))) {
-			const file = await fs.readFile(path_input, "utf-8");
-			await fs.writeFile(path_input, file.replace(/\r/g, ''));
+		if (process.platform === 'win32' && !exists(path_ple)) {
+			const file = fs.readFileSync(path_input, "utf-8");
+			fs.writeFileSync(path_input, file.replace(/\r/g, ''));
 		}
 
 		const result = await linter.lintFiles(path_input);
 
 		const actual = result[0] ? result[0].messages : [];
-		const expected = JSON.parse(await fs.readFile(path_expected, "utf-8"));
+		const expected = JSON.parse(fs.readFileSync(path_expected, "utf-8"));
 
-		await fs.writeFile(path_actual, JSON.stringify(actual, null, '\t'));
+		fs.writeFileSync(path_actual, JSON.stringify(actual, null, '\t'));
 
 		assert.equal(actual.length, expected.length);
 		assert.deepStrictEqual(actual, actual.map((msg, i) => ({ ...msg, ...expected[i] })));
@@ -37,9 +37,9 @@ async function run() {
 	}
 }
 
-async function exists(path) {
+function exists(path) {
 	try {
-		await fs.access(path);
+		fs.accessSync(path);
 		return true;
 	} catch (err) {
 		return false;

--- a/test/index.js
+++ b/test/index.js
@@ -2,23 +2,48 @@
 
 process.chdir(__dirname);
 
-const { CLIEngine } = require('eslint');
+const { ESLint } = require('eslint');
 const assert = require('assert');
-const fs = require('fs');
+const fs = require('fs/promises');
 
-const cli = new CLIEngine({ reportUnusedDisableDirectives: true });
+const linter = new ESLint({ reportUnusedDisableDirectives: "error" });
 
-for (const name of fs.readdirSync('samples')) {
-	if (name[0] !== '.') {
+async function run() {
+	const tests = (await fs.readdir('samples')).filter(name => name[0] !== '.');
+
+	for (const name of tests) {
 		console.log(name);
-		if (process.platform === 'win32' && !fs.existsSync(`samples/${name}/preserve_line_endings`)) {
-			fs.writeFileSync(`samples/${name}/Input.svelte`, fs.readFileSync(`samples/${name}/Input.svelte`).toString().replace(/\r/g, ''));
+
+		const path_input = `samples/${name}/Input.svelte`;
+		const path_ple = `samples/${name}/preserve_line_endings`;
+		const path_expected = `samples/${name}/expected.json`;
+		const path_actual = `samples/${name}/actual.json`;
+
+		if (process.platform === 'win32' && !(await exists(path_ple))) {
+			const file = await fs.readFile(path_input, "utf-8");
+			await fs.writeFile(path_input, file.replace(/\r/g, ''));
 		}
-		const actual_messages = cli.executeOnFiles([`samples/${name}/Input.svelte`]).results[0].messages;
-		fs.writeFileSync(`samples/${name}/actual.json`, JSON.stringify(actual_messages, null, '\t'));
-		const expected_messages = JSON.parse(fs.readFileSync(`samples/${name}/expected.json`).toString());
-		assert.equal(actual_messages.length, expected_messages.length);
-		assert.deepStrictEqual(actual_messages, actual_messages.map((message, i) => ({ ...message, ...expected_messages[i] })));
+
+		const result = await linter.lintFiles(path_input);
+
+		const actual = result[0] ? result[0].messages : [];
+		const expected = JSON.parse(await fs.readFile(path_expected, "utf-8"));
+
+		await fs.writeFile(path_actual, JSON.stringify(actual, null, '\t'));
+
+		assert.equal(actual.length, expected.length);
+		assert.deepStrictEqual(actual, actual.map((msg, i) => ({ ...msg, ...expected[i] })));
 		console.log('passed!\n');
 	}
 }
+
+async function exists(path) {
+	try {
+		await fs.access(path);
+		return true;
+	} catch (err) {
+		return false;
+	}
+}
+
+run();

--- a/test/samples/typescript-inline-type-import/.eslintrc.js
+++ b/test/samples/typescript-inline-type-import/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+	parser: '@typescript-eslint/parser',
+	plugins: ['@typescript-eslint'],
+	settings: {
+		'svelte3/typescript': require('typescript'),
+	},
+	rules: {
+		'no-unused-vars': 'error',
+	},
+};

--- a/test/samples/typescript-inline-type-import/Input.svelte
+++ b/test/samples/typescript-inline-type-import/Input.svelte
@@ -1,0 +1,10 @@
+<script lang='ts'>
+	import Component from './Component.svelte';
+	import UnusedComponent from './UnusedComponent.svelte';
+	import { Thing1, Thing2, UnusedThing, type Type, type UnusedType } from './things';
+	const a: Type = new Thing1();
+	a;
+</script>
+
+<div on:click={() => new Thing2()}></div>
+<Component />

--- a/test/samples/typescript-inline-type-import/expected.json
+++ b/test/samples/typescript-inline-type-import/expected.json
@@ -1,0 +1,35 @@
+[
+	{
+		"ruleId": "no-unused-vars",
+		"severity": 2,
+		"message": "'UnusedComponent' is defined but never used.",
+		"line": 3,
+		"column": 9,
+		"nodeType": "Identifier",
+		"messageId": "unusedVar",
+		"endLine": 3,
+		"endColumn": 24
+	},
+	{
+		"ruleId": "no-unused-vars",
+		"severity": 2,
+		"message": "'UnusedThing' is defined but never used.",
+		"line": 4,
+		"column": 27,
+		"nodeType": "Identifier",
+		"messageId": "unusedVar",
+		"endLine": 4,
+		"endColumn": 38
+	},
+	{
+		"ruleId": "no-unused-vars",
+		"severity": 2,
+		"message": "'UnusedType' is defined but never used.",
+		"line": 4,
+		"column": 56,
+		"nodeType": "Identifier",
+		"messageId": "unusedVar",
+		"endLine": 4,
+		"endColumn": 66
+	}
+]


### PR DESCRIPTION
Fixes #154
Closes #142 

I also updated the package's dev-dependencies to use the latest TypeScript stuff. I did this so that I could add a test for checking if the inline type import syntax works.