### PR TITLE
(fix) better fix range handling

### DIFF
--- a/src/block.js
+++ b/src/block.js
@@ -13,10 +13,11 @@ export const get_translation = (text, block, node, options = {}) => {
 	block.transformed_code += '\n';
 	const translation = { options, unoffsets: get_offsets(block.transformed_code) };
 	translation.range = [node.start, node.end];
-	const { dedented, offsets } = dedent_code(text.slice(node.start, node.end));
+	const { dedented, offsets, indentation } = dedent_code(text.slice(node.start, node.end));
 	block.transformed_code += dedented;
 	translation.offsets = get_offsets(text.slice(0, node.start));
 	translation.dedent = offsets;
+	translation.indentation = indentation;
 	translation.end = get_offsets(block.transformed_code).lines;
 	for (let i = translation.unoffsets.lines; i <= translation.end; i++) {
 		block.translations.set(i, translation);

--- a/src/mapping.js
+++ b/src/mapping.js
@@ -137,7 +137,7 @@ export class DocumentMapper {
  * @param position Line and character position
  * @param text The text for which the offset should be retrieved
  */
-function offset_at(position, text) {
+export function offset_at(position, text) {
 	const line_offsets = get_line_offsets(text);
 
 	if (position.line >= line_offsets.length) {
@@ -153,7 +153,12 @@ function offset_at(position, text) {
 	return clamp(next_line_offset, line_offset, line_offset + position.column);
 }
 
-function position_at(offset, text) {
+/**
+ * Get the line and character position of an offset
+ * @param offset Idx of the offset
+ * @param text The text for which the position should be retrieved
+ */
+export function position_at(offset, text) {
 	offset = clamp(offset, 0, text.length);
 
 	const line_offsets = get_line_offsets(text);

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,7 +46,7 @@ export const dedent_code = str => {
 		}
 		dedented += str[i];
 	}
-	return { dedented, offsets: { offsets, total_offsets } };
+	return { dedented, offsets: { offsets, total_offsets }, indentation };
 };
 
 // get character offsets of each line in a string

--- a/test/index.js
+++ b/test/index.js
@@ -3,10 +3,11 @@
 process.chdir(__dirname);
 
 const { ESLint } = require('eslint');
+const { SourceCodeFixer } = require('eslint/lib/linter');
 const assert = require('assert');
 const fs = require('fs');
 
-const linter = new ESLint({ reportUnusedDisableDirectives: "error" });
+const linter = new ESLint({ reportUnusedDisableDirectives: 'error' });
 
 async function run() {
 	const tests = fs.readdirSync('samples').filter(name => name[0] !== '.');
@@ -15,24 +16,31 @@ async function run() {
 		console.log(name);
 
 		const path_input = `samples/${name}/Input.svelte`;
+		const path_fixed = `samples/${name}/Fixed.svelte`;
 		const path_ple = `samples/${name}/preserve_line_endings`;
 		const path_expected = `samples/${name}/expected.json`;
 		const path_actual = `samples/${name}/actual.json`;
 
 		if (process.platform === 'win32' && !exists(path_ple)) {
-			const file = fs.readFileSync(path_input, "utf-8");
+			const file = fs.readFileSync(path_input, 'utf-8');
 			fs.writeFileSync(path_input, file.replace(/\r/g, ''));
 		}
 
 		const result = await linter.lintFiles(path_input);
 
 		const actual = result[0] ? result[0].messages : [];
-		const expected = JSON.parse(fs.readFileSync(path_expected, "utf-8"));
+		const expected = JSON.parse(fs.readFileSync(path_expected, 'utf-8'));
 
 		fs.writeFileSync(path_actual, JSON.stringify(actual, null, '\t'));
 
 		assert.equal(actual.length, expected.length);
 		assert.deepStrictEqual(actual, actual.map((msg, i) => ({ ...msg, ...expected[i] })));
+		
+		if (fs.existsSync(path_fixed)) {
+			const fixed = SourceCodeFixer.applyFixes(fs.readFileSync(path_input, 'utf-8'), actual).output;
+			assert.deepStrictEqual(fixed, fs.readFileSync(path_fixed, 'utf-8'))
+		}
+
 		console.log('passed!\n');
 	}
 }

--- a/test/samples/multiline-fixes/.eslintrc.js
+++ b/test/samples/multiline-fixes/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+	rules: {
+		curly: 'error',
+		'no-else-return': 'error',
+		'no-lonely-if': 'error',
+	},
+};

--- a/test/samples/multiline-fixes/Fixed.svelte
+++ b/test/samples/multiline-fixes/Fixed.svelte
@@ -1,0 +1,24 @@
+<script>
+    if (window.foo)
+        {window.foo =
+            window.bar
+                .toLowerCase()
+                .replace('something', 'else')
+                .trim();}
+
+    function noElseReturn() {
+        if (window) {
+            return 'foo';
+        } 
+            return 'bar';
+        
+    }
+
+    function noLonelyIf() {
+        if (window) {
+            doX();
+        } else if (!window) {
+                doY();
+            }
+    }
+</script>

--- a/test/samples/multiline-fixes/Input.svelte
+++ b/test/samples/multiline-fixes/Input.svelte
@@ -1,0 +1,26 @@
+<script>
+    if (window.foo)
+        window.foo =
+            window.bar
+                .toLowerCase()
+                .replace('something', 'else')
+                .trim();
+
+    function noElseReturn() {
+        if (window) {
+            return 'foo';
+        } else {
+            return 'bar';
+        }
+    }
+
+    function noLonelyIf() {
+        if (window) {
+            doX();
+        } else {
+            if (!window) {
+                doY();
+            }
+        }
+    }
+</script>

--- a/test/samples/multiline-fixes/expected.json
+++ b/test/samples/multiline-fixes/expected.json
@@ -1,0 +1,56 @@
+[
+	{
+		"ruleId": "curly",
+		"severity": 2,
+		"message": "Expected { after 'if' condition.",
+		"line": 3,
+		"column": 9,
+		"nodeType": "IfStatement",
+		"messageId": "missingCurlyAfterCondition",
+		"endLine": 7,
+		"endColumn": 25,
+		"fix": {
+			"range": [
+				37,
+				174
+			],
+			"text": "{window.foo =\n            window.bar\n                .toLowerCase()\n                .replace('something', 'else')\n                .trim();}"
+		}
+	},
+	{
+		"ruleId": "no-else-return",
+		"severity": 2,
+		"message": "Unnecessary 'else' after 'return'.",
+		"line": 12,
+		"column": 16,
+		"nodeType": "BlockStatement",
+		"messageId": "unexpected",
+		"endLine": 14,
+		"endColumn": 10,
+		"fix": {
+			"range": [
+				264,
+				306
+			],
+			"text": "\n            return 'bar';\n        "
+		}
+	},
+	{
+		"ruleId": "no-lonely-if",
+		"severity": 2,
+		"message": "Unexpected if as the only statement in an else block.",
+		"line": 21,
+		"column": 13,
+		"nodeType": "IfStatement",
+		"messageId": "unexpectedLonelyIf",
+		"endLine": 23,
+		"endColumn": 14,
+		"fix": {
+			"range": [
+				398,
+				468
+			],
+			"text": "if (!window) {\n                doY();\n        "
+		}
+	}
+]

--- a/test/samples/typescript-multiline-fixes/.eslintrc.js
+++ b/test/samples/typescript-multiline-fixes/.eslintrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+	parser: '@typescript-eslint/parser',
+	plugins: ['@typescript-eslint'],
+	settings: {
+		'svelte3/typescript': require('typescript'),
+	},
+	rules: {
+		curly: 'error',
+		'no-else-return': 'error',
+		'no-lonely-if': 'error',
+	},
+};

--- a/test/samples/typescript-multiline-fixes/Fixed.svelte
+++ b/test/samples/typescript-multiline-fixes/Fixed.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    interface Foo {}
+
+    if (window.foo)
+        {window.foo =
+            window.bar
+                .toLowerCase()
+                .replace('something' as string, 'else')
+                .trim();}
+
+    function noElseReturn(): string {
+        if (window) {
+            return 'foo';
+        } 
+            return 'bar' as string;
+        
+    }
+
+    function noLonelyIf(): void {
+        if (window) {
+            doX();
+        } else if (!window) {
+                (doY as any)();
+            }
+    }
+</script>

--- a/test/samples/typescript-multiline-fixes/Input.svelte
+++ b/test/samples/typescript-multiline-fixes/Input.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+    interface Foo {}
+
+    if (window.foo)
+        window.foo =
+            window.bar
+                .toLowerCase()
+                .replace('something' as string, 'else')
+                .trim();
+
+    function noElseReturn(): string {
+        if (window) {
+            return 'foo';
+        } else {
+            return 'bar' as string;
+        }
+    }
+
+    function noLonelyIf(): void {
+        if (window) {
+            doX();
+        } else {
+            if (!window) {
+                (doY as any)();
+            }
+        }
+    }
+</script>

--- a/test/samples/typescript-multiline-fixes/expected.json
+++ b/test/samples/typescript-multiline-fixes/expected.json
@@ -1,0 +1,56 @@
+[
+	{
+		"ruleId": "curly",
+		"severity": 2,
+		"message": "Expected { after 'if' condition.",
+		"line": 5,
+		"column": 9,
+		"nodeType": "IfStatement",
+		"messageId": "missingCurlyAfterCondition",
+		"endLine": 9,
+		"endColumn": 25,
+		"fix": {
+			"range": [
+				69,
+				216
+			],
+			"text": "{window.foo =\n            window.bar\n                .toLowerCase()\n                .replace('something' as string, 'else')\n                .trim();}"
+		}
+	},
+	{
+		"ruleId": "no-else-return",
+		"severity": 2,
+		"message": "Unnecessary 'else' after 'return'.",
+		"line": 14,
+		"column": 16,
+		"nodeType": "BlockStatement",
+		"messageId": "unexpected",
+		"endLine": 16,
+		"endColumn": 10,
+		"fix": {
+			"range": [
+				314,
+				366
+			],
+			"text": "\n            return 'bar' as string;\n        "
+		}
+	},
+	{
+		"ruleId": "no-lonely-if",
+		"severity": 2,
+		"message": "Unexpected if as the only statement in an else block.",
+		"line": 23,
+		"column": 13,
+		"nodeType": "IfStatement",
+		"messageId": "unexpectedLonelyIf",
+		"endLine": 25,
+		"endColumn": 14,
+		"fix": {
+			"range": [
+				464,
+				543
+			],
+			"text": "if (!window) {\n                (doY as any)();\n        "
+		}
+	}
+]


### PR DESCRIPTION
Fixes don't need to start at the same line where the error message is shown, and they don't need to be at the same line as the start of the error message. Therefore the previous handling of re-adding dedents was flawed. Instead, map the range to positions (line/character) and use them to find the correct dedent offsets.
Additionally add indentation after each newline a fix has because the fix doesn't know about the additional indentation.

To properly test fixes, the test setup was enhanced. If there's a Fixed.svelte, that one will be compared against a fixed version of Input.svelte.

Fixes #110
Fixes #156
Fixes #157